### PR TITLE
Upgrades classycle to 1.4.3 for java 1.6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>org.specs2</groupId>
 			<artifactId>classycle</artifactId>
-			<version>1.4.1</version>
+			<version>1.4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Looks like Classycle 1.4.1 is not compatible with Java 1.6.  1.4.3 however is, so this pull request upgrades it to the latest version in order to support an older version of Java, oddly enough.
