### PR TITLE
Allows specifying project report encoding

### DIFF
--- a/src/main/java/org/pitest/classycle/ClassycleMojo.java
+++ b/src/main/java/org/pitest/classycle/ClassycleMojo.java
@@ -26,7 +26,7 @@ public abstract class ClassycleMojo extends AbstractMojo implements Project {
   /**
    * @parameter expression="${project.reporting.outputEncoding}" default-value="UTF-8"
    */
-  protected String reportEncoding;
+  private String reportEncoding;
 
   /**
    * List of zero or more wild-card patterns for fully-qualified class names

--- a/src/main/java/org/pitest/classycle/ClassycleMojo.java
+++ b/src/main/java/org/pitest/classycle/ClassycleMojo.java
@@ -24,6 +24,11 @@ public abstract class ClassycleMojo extends AbstractMojo implements Project {
   private boolean      mergeInnerClasses;
 
   /**
+   * @parameter expression="${project.reporting.outputEncoding}" default-value="UTF-8"
+   */
+  protected String reportEncoding;
+
+  /**
    * List of zero or more wild-card patterns for fully-qualified class names
    * which are referred in the class file by plain string constants. Only '*' is
    * interpreted as wild-card character.
@@ -71,4 +76,7 @@ public abstract class ClassycleMojo extends AbstractMojo implements Project {
     return this.excludingClasses;
   }
 
+  public final String getReportEncoding() {
+    return this.reportEncoding;
+  }
 }

--- a/src/main/java/org/pitest/classycle/Project.java
+++ b/src/main/java/org/pitest/classycle/Project.java
@@ -16,4 +16,5 @@ public interface Project {
 
   List<String> getExcludingClasses();
 
+  String getReportEncoding();
 }

--- a/src/main/java/org/pitest/classycle/analyse/AnalyseGoal.java
+++ b/src/main/java/org/pitest/classycle/analyse/AnalyseGoal.java
@@ -2,6 +2,7 @@ package org.pitest.classycle.analyse;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
 import org.pitest.classycle.AbstractGoal;
@@ -25,14 +26,13 @@ class AnalyseGoal extends AbstractGoal<AnalyseProject> {
   }
 
   private void writeReport(final Analyser analyser) throws IOException {
-    final PrintWriter writer = new PrintWriter(
-        this.streamFactory.createStream(XML_FILE));
+    final PrintWriter writer = new PrintWriter(new OutputStreamWriter(
+        this.streamFactory.createStream(XML_FILE), project.getReportEncoding()));
     analyser.printXML(this.project.getTitle(), this.project.isPackagesOnly(),
         writer);
     writer.close();
 
     copyResourceForHtmlViewing();
-
   }
 
   private void copyResourceForHtmlViewing() throws IOException {

--- a/src/main/java/org/pitest/classycle/check/CheckGoal.java
+++ b/src/main/java/org/pitest/classycle/check/CheckGoal.java
@@ -1,6 +1,7 @@
 package org.pitest.classycle.check;
 
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Properties;
 
@@ -26,8 +27,8 @@ class CheckGoal extends AbstractGoal<CheckProject> {
     final Properties properties = System.getProperties();
     final DependencyChecker dependencyChecker = new DependencyChecker(analyser,
         this.project.getDependencyDefinition(), properties, getRenderer());
-    final PrintWriter printWriter = new PrintWriter(
-        this.streamFactory.createStream(RESULTS_FILE));
+    final PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(
+        this.streamFactory.createStream(RESULTS_FILE), project.getReportEncoding()));
     try {
       if (!dependencyChecker.check(printWriter)) {
         return !this.project.isFailOnUnWantedDependencies();

--- a/src/test/java/org/pitest/classycle/analyse/AnalyseGoalTest.java
+++ b/src/test/java/org/pitest/classycle/analyse/AnalyseGoalTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.CharEncoding;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,6 +35,7 @@ public class AnalyseGoalTest {
     when(this.project.getOutputDirectory()).thenReturn(testOutput());
     when(this.project.getExcludingClasses()).thenReturn(null);
     when(this.project.getTitle()).thenReturn("title");
+    when(this.project.getReportEncoding()).thenReturn(CharEncoding.UTF_8);
     this.sf = createStreamFactory();
     this.testee = new AnalyseGoal(this.project, this.sf);
   }

--- a/src/test/java/org/pitest/classycle/check/CheckGoalTest.java
+++ b/src/test/java/org/pitest/classycle/check/CheckGoalTest.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.CharEncoding;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -37,6 +38,7 @@ public class CheckGoalTest {
     MockitoAnnotations.initMocks(this);
     when(this.project.getOutputDirectory()).thenReturn(testOutput());
     when(this.project.getExcludingClasses()).thenReturn(null);
+    when(this.project.getReportEncoding()).thenReturn(CharEncoding.UTF_8);
     this.sf = createStreamFactory();
     this.testee = new CheckGoal(this.project, this.sf);
   }


### PR DESCRIPTION
I've noticed that the output files generated by this plugin are not always in UTF-8 so this pull request allows the plugin to pick up the project's report output encoding via the `${project.reporting.outputEncoding}` Maven property.  It defaults to UTF-8 if this is not set.
