### PR TITLE
Allows for xml output from check goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Classycle rules can be supplied via a file specified with the dependencyDefiniti
 <plugin>
 	<groupId>org.pitest</groupId>
 	<artifactId>classycle</artifactId>
-	<version>0.2</version>
+	<version>0.4</version>
 	<executions>
 		<execution>
 			<id>verify</id>
@@ -37,11 +37,15 @@ Classycle rules can be supplied via a file specified with the dependencyDefiniti
 					show allResults
 					check absenceOfPackageCycles > 1 in com.example*
 				</dependencyDefinition>
+
+				<!-- This can be classycle.dependency.DefaultResultRenderer 
+					for text (the default if omitted) or 
+					classycle.dependency.XMLResultRenderer for xml -->
+				<resultRenderer>classycle.dependency.DefaultResultRenderer</resultRenderer>
 			</configuration>
 		</execution>
 	</executions>
 </plugin>
-
 ```
 
 If both a file and an embedded definition are supplied, the file will be used.

--- a/src/main/java/org/pitest/classycle/check/CheckGoal.java
+++ b/src/main/java/org/pitest/classycle/check/CheckGoal.java
@@ -9,13 +9,10 @@ import org.pitest.classycle.AbstractGoal;
 import org.pitest.classycle.StreamFactory;
 
 import classycle.Analyser;
-import classycle.dependency.DefaultResultRenderer;
 import classycle.dependency.DependencyChecker;
 import classycle.dependency.ResultRenderer;
 
 class CheckGoal extends AbstractGoal<CheckProject> {
-
-  static final String RESULTS_FILE = "checkresults.txt";
 
   CheckGoal(final CheckProject project, final StreamFactory streamFactory) {
     super(project, streamFactory);
@@ -28,7 +25,7 @@ class CheckGoal extends AbstractGoal<CheckProject> {
     final DependencyChecker dependencyChecker = new DependencyChecker(analyser,
         this.project.getDependencyDefinition(), properties, getRenderer());
     final PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(
-        this.streamFactory.createStream(RESULTS_FILE), project.getReportEncoding()));
+        this.streamFactory.createStream(project.getOutputFile()), project.getReportEncoding()));
     try {
       if (!dependencyChecker.check(printWriter)) {
         return !this.project.isFailOnUnWantedDependencies();
@@ -40,7 +37,13 @@ class CheckGoal extends AbstractGoal<CheckProject> {
   }
 
   private ResultRenderer getRenderer() {
-    return new DefaultResultRenderer();
+    try {
+      return project.getResultRenderer().newInstance();
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Could not instantiate " + project.getResultRenderer(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Could not access " + project.getResultRenderer(), e);
+    }
   }
 
 }

--- a/src/main/java/org/pitest/classycle/check/CheckProject.java
+++ b/src/main/java/org/pitest/classycle/check/CheckProject.java
@@ -4,8 +4,14 @@ import java.io.IOException;
 
 import org.pitest.classycle.Project;
 
+import classycle.dependency.ResultRenderer;
+
 public interface CheckProject extends Project {
   String getDependencyDefinition() throws IOException;
 
   boolean isFailOnUnWantedDependencies();
+
+  Class<? extends ResultRenderer> getResultRenderer();
+
+  String getOutputFile();
 }

--- a/src/test/java/org/pitest/classycle/check/CheckGoalTest.java
+++ b/src/test/java/org/pitest/classycle/check/CheckGoalTest.java
@@ -19,6 +19,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.pitest.classycle.StreamFactory;
 
+import classycle.dependency.DefaultResultRenderer;
+
 public class CheckGoalTest {
 
   private final String                             CHECK_THAT_WILL_FAIL     = "[A] = Doesnotexit \n check sets [A]";
@@ -39,6 +41,9 @@ public class CheckGoalTest {
     when(this.project.getOutputDirectory()).thenReturn(testOutput());
     when(this.project.getExcludingClasses()).thenReturn(null);
     when(this.project.getReportEncoding()).thenReturn(CharEncoding.UTF_8);
+
+    Class renderer = DefaultResultRenderer.class;
+    when(this.project.getResultRenderer()).thenReturn(renderer);
     this.sf = createStreamFactory();
     this.testee = new CheckGoal(this.project, this.sf);
   }
@@ -99,9 +104,10 @@ public class CheckGoalTest {
   public void shouldWriteReportToFile() throws IOException {
     when(this.project.getDependencyDefinition()).thenReturn(
         this.CHECK_THAT_WILL_NOT_FAIL);
+    when(this.project.getOutputFile()).thenReturn(CheckMojo.TEXT_RESULT_FILE);
     this.testee.analyse();
-    System.out.println(this.output.get(CheckGoal.RESULTS_FILE));
-    assertThat(this.output.get(CheckGoal.RESULTS_FILE)).isNotNull();
+    System.out.println(this.output.get(CheckMojo.TEXT_RESULT_FILE));
+    assertThat(this.output.get(CheckMojo.TEXT_RESULT_FILE)).isNotNull();
   }
 
 }


### PR DESCRIPTION
At the moment the check goal outputs a text file with the violations in it.  This pull request allows for using the `XMLResultRenderer` supplied with Classycle by specifying a `resultRenderer` argument.

If none is specified, the `DefaultResultRenderer` will be used and a text file will be output the same as now.
