### PR TITLE
Fixed issue that leads to failing build when target directory does not exists

### DIFF
--- a/src/main/java/org/pitest/classycle/AbstractGoal.java
+++ b/src/main/java/org/pitest/classycle/AbstractGoal.java
@@ -26,6 +26,10 @@ public abstract class AbstractGoal<T extends Project> {
   public final boolean analyse() throws IOException {
     final File classDir = new File(this.project.getOutputDirectory());
 
+    if(!classDir.exists()) {
+    	return true;
+    }
+    
     final Analyser analyser = createAnalyser(
         new String[] { classDir.getAbsolutePath() }, getPattern(),
         getReflectionPattern(), this.project.isMergeInnerClasses());

--- a/src/test/java/org/pitest/classycle/analyse/AnalyseGoalTest.java
+++ b/src/test/java/org/pitest/classycle/analyse/AnalyseGoalTest.java
@@ -1,6 +1,7 @@
 package org.pitest.classycle.analyse;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
@@ -145,6 +146,14 @@ public class AnalyseGoalTest {
   public void shouldWriteImagesOutputDir() throws IOException {
     this.testee.analyse();
     assertThat(this.output.get("images/class.png")).isNotNull();
+  }
+  
+  @Test
+  public void shouldNotFailWhenOutputDirDoesNotExists()
+      throws IOException {
+    when(this.project.getOutputDirectory()).thenReturn("/some/dummy/directory");
+    
+    assertTrue(this.testee.analyse());
   }
 
   String xmlOutput() {


### PR DESCRIPTION
Plugin should not lead to a failing build when there is nothing to validate. Same behavior as for standard maven plugins should apply.

Fixed this with the pull request.
